### PR TITLE
[fix] Unity2018.3以降のNestedPrefabだとSetParentが動作していなかった問題を修正

### DIFF
--- a/Assets/UnityWearChangeSupporter/Scripts/Editor/UnityWearChangeSupporter.cs
+++ b/Assets/UnityWearChangeSupporter/Scripts/Editor/UnityWearChangeSupporter.cs
@@ -333,6 +333,11 @@ namespace VRChatUtilIzm
 
             cloth.transform.SetParent(character.transform);
 
+#if UNITY_2018_3_OR_NEWER
+            PrefabUtility.UnpackPrefabInstance(cloth.gameObject, PrefabUnpackMode.OutermostRoot,
+                InteractionMode.AutomatedAction);
+#endif
+
             foreach (var VARIABLE in clothHumanBoneDictionary)
             {
                 Transform willParent = character.GetBoneTransform(VARIABLE.Key);


### PR DESCRIPTION
Unity2018.3以降のNestedPrefabは、その子にあるオブジェクトを操作する前にUnpackしないとエラーになってしまうため、UnpackしてからSetParentするように修正しました